### PR TITLE
Added a SCONE modifier based on TC filters for ingress and egress

### DIFF
--- a/scone_modifier_ebpf_tc.c
+++ b/scone_modifier_ebpf_tc.c
@@ -1,0 +1,97 @@
+// This contains only the modifier eBPF function, in accordance with draft 03
+// This version is implemented as a tc filter, which allows it to be attached to ingress and egress.
+// Using scone_modifier_tc.py, it is possible to dynamically change the advertised rate.
+
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+#include <linux/ip.h>
+#include <linux/ipv6.h>
+#include <linux/udp.h>
+#include <linux/pkt_cls.h>
+#include <bcc/proto.h>
+
+#define SCONE_VERSION 0x6f7dc0fd
+
+// Rate we want to introduce at this point
+BPF_ARRAY(scone_rate, u8, 1);
+
+struct sconepkt
+{
+    u8 rate_signal : 6; // LSB first
+    u8 type : 2;
+    u32 version;
+} __attribute__((packed));
+
+// Borrowed from: https://gist.github.com/sbernard31/d4fee7518a1ff130452211c0d355b3f7
+__attribute__((__always_inline__)) static inline __u16 csum_fold_helper(__u64 csum)
+{
+    int i;
+#pragma unroll
+    for (i = 0; i < 4; i++)
+    {
+        if (csum >> 16)
+            csum = (csum & 0xffff) + (csum >> 16);
+    }
+    return ~csum;
+}
+
+int modify_scone_ebpf(struct __sk_buff *skb)
+{
+    void *data = (void *)(long)skb->data;
+    void *data_end = (void *)(long)skb->data_end;
+
+    struct ethhdr *eth = data;
+    struct iphdr *ip = (void *)eth + sizeof(*eth);
+    struct udphdr *udp = (void *)ip + sizeof(*ip);
+    struct sconepkt *quic = (void *)udp + sizeof(*udp);
+
+    // Check length
+    if ((void *)quic + sizeof(*quic) > data_end)
+    {
+        return TC_ACT_OK;
+    }
+
+    // Check for IPv4
+    u16 ipproto = bpf_ntohs(eth->h_proto);
+    if (ipproto != ETH_P_IP)
+    {
+        return TC_ACT_OK;
+    }
+
+    // Check for UDP
+    if (ip->protocol != IPPROTO_UDP)
+    {
+        return TC_ACT_OK;
+    }
+
+    // Check long header
+    if (!(quic->type & 2))
+    {
+        return TC_ACT_OK;
+    }
+
+    u32 index = 0;
+    u8 *rate_ptr = (u8 *)scone_rate.lookup(&index);
+    if (rate_ptr == NULL)
+    {
+        return TC_ACT_OK;
+    }
+    u8 rate = *rate_ptr;
+
+    if ((bpf_ntohl(quic->version) & 0x7fffffff) != SCONE_VERSION)
+    {
+        return TC_ACT_OK;
+    }
+
+    if ((quic->rate_signal << 1) + (bpf_ntohl(quic->version) >> 31) <= rate)
+    {
+        return TC_ACT_OK;
+    }
+
+    quic->version = bpf_htonl(SCONE_VERSION | (0x80000000 * (rate & 0x1)));
+    quic->rate_signal = rate >> 1;
+
+    // In the TC path, we do not need to modify the checksum, as it seems to be a partial one (maybe only over the header)
+
+    return TC_ACT_OK;
+}

--- a/scone_modifier_ebpf_tc.c
+++ b/scone_modifier_ebpf_tc.c
@@ -22,19 +22,6 @@ struct sconepkt
     u32 version;
 } __attribute__((packed));
 
-// Borrowed from: https://gist.github.com/sbernard31/d4fee7518a1ff130452211c0d355b3f7
-__attribute__((__always_inline__)) static inline __u16 csum_fold_helper(__u64 csum)
-{
-    int i;
-#pragma unroll
-    for (i = 0; i < 4; i++)
-    {
-        if (csum >> 16)
-            csum = (csum & 0xffff) + (csum >> 16);
-    }
-    return ~csum;
-}
-
 int modify_scone_ebpf(struct __sk_buff *skb)
 {
     void *data = (void *)(long)skb->data;

--- a/scone_modifier_tc.py
+++ b/scone_modifier_tc.py
@@ -1,0 +1,56 @@
+from bcc import BPF
+from bcc.utils import printb
+import ctypes as ct
+from pyroute2 import IPRoute
+
+import signal
+import sys
+import time
+import os
+
+if len(sys.argv) != 3:
+    print("Usage: %s <ifdev> <direction>" % sys.argv[0])
+    exit(1)
+
+device = sys.argv[1]
+direction = sys.argv[2]
+
+if direction not in ["ingress", "egress"]:
+    print("Direction must be either 'ingress' or 'egress'")
+    exit(1)
+
+b = BPF(src_file="scone_modifier_ebpf_tc.c") # pyright: ignore[reportArgumentType]
+fn = b.load_func("modify_scone_ebpf", BPF.SCHED_CLS)
+print(f"  Attaching modifier for {direction} packets on device {device}.")
+
+def signal_handler(sig, frame):
+    os.system(f"tc filter del dev {device} {direction}")
+    print(f"Detached from {device}.")
+    exit(0)
+
+signal.signal(signal.SIGINT, signal_handler)
+
+ipr = IPRoute()
+
+idx = ipr.link_lookup(ifname=device)[0]
+
+try:
+    ipr.tc("add", "clsact", idx)
+except Exception as e:
+    print("Queue discipline 'clsact' already exists. Continuing...")
+
+ipr.tc("add-filter", "bpf", idx, ":1", fd=fn.fd, name=fn.name, parent="ffff:fff3" if direction == "egress" else "ffff:fff2", classid=1, direct_action=True)
+print(f"Successfully attached eBPF TC program to {device} {direction}.")
+os.system(f"tc filter show dev {device} {direction}")
+print("Press Ctrl+C to detach.")
+
+config = b.get_table("scone_rate")
+rate = 1
+
+while True:
+    #time.sleep(1)
+    config[ct.c_int(0)] = ct.c_ubyte(rate)
+    print(f"Current rate: {rate} ({f'{0.1*10**(rate/20)} Mbps/{0.0125*10**(rate/20)} MBps' if rate < 127 else 'No limit'})")
+    rate = int(input((f"New rate (Ctrl-C to stop): ")))
+    if rate < 0: rate = 0
+    if rate > 127: rate = 127


### PR DESCRIPTION
In order to allow the modification of SCONE packets in both directions on a network interface, I added another eBPF based on TC filters that can be attached both as ingress and egress.

For now, you can have to start the program for each direction independently.

```
$ sudo python3 scone_modifier_tc.py eno1 ingress
  Attaching modifier for ingress packets on device eno1.
Queue discipline 'clsact' already exists. Continuing...
Successfully attached eBPF TC program to eno1 ingress.
filter protocol all pref 49152 bpf chain 0 
filter protocol all pref 49152 bpf chain 0 handle 0x1 flowid :1 modify_scone_ebpf direct-action not_in_hw id 361 tag 68ba87c835ce7796 jited 
Press Ctrl+C to detach.
Current rate: 1 (0.11220184543019635 Mbps/0.014025230678774543 MBps)
New rate (Ctrl-C to stop): 20
Current rate: 20 (1.0 Mbps/0.125 MBps)
New rate (Ctrl-C to stop): Detached from eno1.
```

Please let me know if I should put it in a separate folder or change anything else.